### PR TITLE
Update Sierra queries and processing to remove duplicate address rows

### DIFF
--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -2,50 +2,54 @@ import os
 
 _NEW_PATRONS_QUERY = '''
     SELECT
-        record_metadata.id, ptype_code, pcode3, home_library_code,
-        TRIM(city) AS city,
-        TRIM(region) AS region,
-        TRIM(postal_code) AS postal_code,
-        TRIM(addr1) AS address,
-        (activity_gmt AT TIME ZONE 'EST')::DATE AS circ_active_date_et,
-        (record_last_updated_gmt AT TIME ZONE 'EST')::DATE
-            AS last_updated_date_et,
-        deletion_date_gmt AS deletion_date_et,
-        creation_date_gmt AS creation_timestamp
-    FROM sierra_view.record_metadata
+        x.id, ptype_code, pcode3, home_library_code,
+        TRIM(city), TRIM(region), TRIM(postal_code), TRIM(addr1),
+        (activity_gmt AT TIME ZONE 'EST')::DATE,
+        (record_last_updated_gmt AT TIME ZONE 'EST')::DATE,
+        deletion_date_gmt,
+        creation_date_gmt
+    FROM (
+        SELECT
+            id, record_last_updated_gmt, deletion_date_gmt, creation_date_gmt
+        FROM sierra_view.record_metadata
+        WHERE record_type_code = 'p'
+            AND creation_date_gmt >= '{cached_creation_dt}'
+        ORDER BY creation_date_gmt
+        LIMIT {limit}) x
     LEFT JOIN sierra_view.patron_record_address
-        ON record_metadata.id = patron_record_address.patron_record_id
+        ON x.id = patron_record_address.patron_record_id
     LEFT JOIN sierra_view.patron_view
-        ON record_metadata.id = patron_view.id
-    WHERE record_metadata.record_type_code = 'p'
-        AND creation_date_gmt >= '{cached_creation_dt}'
-    ORDER BY creation_date_gmt
-    LIMIT {limit};'''
+        ON x.id = patron_view.id
+    ORDER BY creation_date_gmt, display_order, patron_record_address_type_id
+    LIMIT {total_limit};'''
 
 _UPDATED_PATRONS_QUERY = '''
     SELECT
-        record_metadata.id, ptype_code, pcode3, home_library_code,
-        TRIM(city) AS city,
-        TRIM(region) AS region,
-        TRIM(postal_code) AS postal_code,
-        TRIM(addr1) AS address,
-        (activity_gmt AT TIME ZONE 'EST')::DATE AS circ_active_date_et,
-        (creation_date_gmt AT TIME ZONE 'EST')::DATE AS creation_date_et,
-        deletion_date_gmt AS deletion_date_et,
-        record_last_updated_gmt AS last_updated_timestamp
-    FROM sierra_view.record_metadata
+        x.id, ptype_code, pcode3, home_library_code,
+        TRIM(city), TRIM(region), TRIM(postal_code), TRIM(addr1),
+        (activity_gmt AT TIME ZONE 'EST')::DATE,
+        (creation_date_gmt AT TIME ZONE 'EST')::DATE,
+        deletion_date_gmt,
+        record_last_updated_gmt
+    FROM (
+        SELECT
+            id, record_last_updated_gmt, deletion_date_gmt, creation_date_gmt
+        FROM sierra_view.record_metadata
+        WHERE record_type_code = 'p'
+            AND record_last_updated_gmt >= '{cached_creation_dt}'
+            AND id NOT IN ({new_patron_ids})
+        ORDER BY record_last_updated_gmt
+        LIMIT {limit}) x
     LEFT JOIN sierra_view.patron_record_address
-        ON record_metadata.id = patron_record_address.patron_record_id
+        ON x.id = patron_record_address.patron_record_id
     LEFT JOIN sierra_view.patron_view
-        ON record_metadata.id = patron_view.id
-    WHERE record_metadata.record_type_code = 'p'
-        AND record_last_updated_gmt >= '{cached_update_dt}'
-        AND record_metadata.id NOT IN ({new_patron_ids})
-    ORDER BY record_last_updated_gmt
-    LIMIT {limit};'''
+        ON x.id = patron_view.id
+    ORDER BY
+        record_last_updated_gmt, display_order, patron_record_address_type_id
+    LIMIT {total_limit};'''
 
 _DELETED_PATRONS_QUERY = '''
-    SELECT id, deletion_date_gmt AS deletion_date_et
+    SELECT id, deletion_date_gmt
     FROM sierra_view.record_metadata
     WHERE record_type_code = 'p'
         AND deletion_date_gmt >= '{cached_deletion_date}'
@@ -55,15 +59,18 @@ _DELETED_PATRONS_QUERY = '''
 
 
 def build_new_patrons_query(creation_dt_start):
-    return _NEW_PATRONS_QUERY.format(cached_creation_dt=creation_dt_start,
-                                     limit=os.environ['SIERRA_BATCH_SIZE'])
+    return _NEW_PATRONS_QUERY.format(
+        cached_creation_dt=creation_dt_start,
+        limit=os.environ['SIERRA_BATCH_SIZE'],
+        total_limit=int(os.environ['SIERRA_BATCH_SIZE']) * 2)
 
 
 def build_updated_patrons_query(update_dt_start, new_patron_ids):
     return _UPDATED_PATRONS_QUERY.format(
         cached_update_dt=update_dt_start,
         new_patron_ids=str(new_patron_ids)[1:-1],
-        limit=os.environ['SIERRA_BATCH_SIZE'])
+        limit=os.environ['SIERRA_BATCH_SIZE'],
+        total_limit=int(os.environ['SIERRA_BATCH_SIZE']) * 2)
 
 
 def build_deleted_patrons_query(deletion_date_start, processed_patron_ids):

--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -5,6 +5,7 @@ from tests.test_helpers import TestHelpers
 
 
 class TestDbClient:
+
     @classmethod
     def setup_class(cls):
         TestHelpers.set_env_vars()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@ import os
 
 class TestHelpers:
     ENV_VARS = {
+        'ENVIRONMENT': 'test_environment',
         'AWS_REGION': 'test_aws_region',
         'AWS_ACCESS_KEY_ID': 'test_aws_key_id',
         'AWS_SECRET_ACCESS_KEY': 'test_aws_secret_key',
@@ -23,7 +24,6 @@ class TestHelpers:
         'KINESIS_BATCH_SIZE': '2',
         'S3_BUCKET': 'test_s3_bucket',
         'S3_RESOURCE': 'test_s3_resource',
-        'SIERRA_BATCH_SIZE': 'test_sierra_batch_size'
     }
 
     @classmethod

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,155 @@
+import datetime
+import os
+import pandas as pd
+import pytest
+import main
+
+from pandas.testing import assert_frame_equal
+from tests.test_helpers import TestHelpers
+
+_EST_TIMEZONE = datetime.timezone(datetime.timedelta(days=-1, seconds=68400))
+
+_POLLER_STATE_1 = {'creation_dt': '2021-01-03 03:04:05-05',
+                   'update_dt': '2021-01-02 02:03:04-04',
+                   'deletion_date': '2021-01-01'}
+
+_SIERRA_RESULTS = [[123, 4, 5, 'home_library1', 'city1', 'region1',
+                    'postal_code1', 'address1', datetime.date(2021, 1, 1),
+                    datetime.date(2021, 1, 2), datetime.date(2021, 1, 3),
+                    datetime.datetime(2020, 12, 31, 23, 59, 59,
+                                      tzinfo=_EST_TIMEZONE)],
+                   [456, 5, 6, 'home_library2', 'city2', 'region2',
+                    'postal_code2', 'address2', datetime.date(2021, 2, 1),
+                    datetime.date(2021, 2, 2), datetime.date(2021, 2, 3),
+                    datetime.datetime(2020, 12, 30, 23, 59, 59,
+                                      tzinfo=_EST_TIMEZONE)],
+                   [456, 6, 7, 'home_library3', 'city3', 'region3',
+                    'postal_code3', 'address3', datetime.date(2021, 3, 1),
+                    datetime.date(2021, 3, 2), datetime.date(2021, 3, 3),
+                    datetime.datetime(2022, 12, 29, 23, 59, 59,
+                                      tzinfo=_EST_TIMEZONE)],
+                   [789, None, None, None, None, None,
+                    None, None, None,
+                    None, None,
+                    datetime.datetime(2022, 1, 1, 1, 1, 1,
+                                      tzinfo=_EST_TIMEZONE)]]
+
+_GEOCODER_INPUT = pd.DataFrame(
+    data=[['123', '4.0', '5.0', 'home_library1', 'city1', 'region1',
+           'postal_code1', 'address1', '2021-01-01', '2021-01-02',
+           '2021-01-03', '2020-12-31 23:59:59-05:00'],
+          ['456', '5.0', '6.0', 'home_library2', 'city2', 'region2',
+           'postal_code2', 'address2', '2021-02-01', '2021-02-02',
+           '2021-02-03', '2020-12-30 23:59:59-05:00'],
+          ['789', None, None, None, None, None,
+           None, None, None, None,
+           None, '2022-01-01 01:01:01-05:00']],
+    dtype='string',
+    columns=['patron_id_plaintext', 'ptype_code', 'pcode3',
+             'patron_home_library_code', 'city', 'region', 'postal_code',
+             'address', 'circ_active_date_et', 'last_updated_date_et',
+             'deletion_date_et', 'creation_timestamp'])
+
+_GEOIDS = pd.Series(['67890', None, '12345'], index=[1, 2, 0], name='geoid')
+
+_AVRO_ENCODER_INPUT = pd.DataFrame(
+    data=[['obfuscated_1', 'obfuscated_4', 'postal_code1', '12345',
+           '2020-12-31', '2021-01-03', '2021-01-01', 4, 5, 'home_library1'],
+          ['obfuscated_2', 'obfuscated_5', 'postal_code2', '67890',
+          '2020-12-30', '2021-02-03', '2021-02-01', 5, 6, 'home_library2'],
+          ['obfuscated_3', 'obfuscated_6', None, None,
+          '2022-01-01', None, None, None, None, None]],
+    columns=['patron_id', 'address_hash', 'postal_code', 'geoid',
+             'creation_date_et', 'deletion_date_et', 'circ_active_date_et',
+             'ptype_code', 'pcode3', 'patron_home_library_code']).astype(
+    {'postal_code': 'string',
+     'deletion_date_et': 'string',
+     'circ_active_date_et': 'string',
+     'ptype_code': 'Int64',
+     'pcode3': 'Int64',
+     'patron_home_library_code': 'string'})
+
+_ENCODED_RECORDS = [b'encoded_1', b'encoded_2', b'encoded_3']
+
+
+class TestMain:
+
+    @classmethod
+    def setup_class(cls):
+        TestHelpers.set_env_vars()
+
+    @classmethod
+    def teardown_class(cls):
+        TestHelpers.clear_env_vars()
+
+    @pytest.fixture
+    def test_helpers(self, mocker):
+        mocker.patch('main.load_env_file')
+        mocker.patch('main.obfuscate', side_effect=[
+                     'obfuscated_{}'.format(n) for n in range(1, 7)])
+        mocker.patch('main.build_new_patrons_query', return_value='TEST QUERY')
+
+    @pytest.fixture
+    def test_s3_client(self, mocker):
+        mock_s3_client = mocker.MagicMock()
+        mock_s3_client.fetch_state.return_value = _POLLER_STATE_1
+        mocker.patch('main.S3Client', return_value=mock_s3_client)
+        return mock_s3_client
+
+    @pytest.fixture
+    def test_sierra_client(self, mocker):
+        mock_sierra_client = mocker.MagicMock()
+        mock_sierra_client.execute_query.return_value = _SIERRA_RESULTS
+        mocker.patch('main.DbClient', return_value=mock_sierra_client)
+        return mock_sierra_client
+
+    @pytest.fixture
+    def test_geocoder_client(self, mocker):
+        mock_geocoder_client = mocker.MagicMock()
+        mock_geocoder_client.get_geoids.return_value = _GEOIDS
+        mocker.patch('main.GeocoderApiClient',
+                     return_value=mock_geocoder_client)
+        return mock_geocoder_client
+
+    @pytest.fixture
+    def test_avro_encoder(self, mocker):
+        mock_avro_encoder = mocker.MagicMock()
+        mock_avro_encoder.encode_batch.return_value = _ENCODED_RECORDS
+        mocker.patch('main.AvroEncoder', return_value=mock_avro_encoder)
+        return mock_avro_encoder
+
+    @pytest.fixture
+    def test_kinesis_client(self, mocker):
+        mock_kinesis_client = mocker.MagicMock()
+        mocker.patch('main.KinesisClient', return_value=mock_kinesis_client)
+        return mock_kinesis_client
+
+    def test_main(
+            self, test_helpers, test_s3_client, test_sierra_client,
+            test_geocoder_client, test_avro_encoder, test_kinesis_client):
+        os.environ['SIERRA_BATCH_SIZE'] = '3'
+        os.environ['MAX_BATCHES'] = '1'
+
+        main.main()
+
+        test_s3_client.fetch_state.assert_called_once()
+        test_sierra_client.execute_query.assert_called_once_with('TEST QUERY')
+
+        # The input check implicitly tests that the raw data is loaded into a
+        # dataframe properly and that duplicate patron ids have been removed
+        test_geocoder_client.get_geoids.assert_called_once()
+        assert_frame_equal(
+            test_geocoder_client.get_geoids.call_args.args[0], _GEOCODER_INPUT)
+
+        # The input check implicitly tests that the geoids have been joined,
+        # the datatypes have been converted, and the id and address have been
+        # obfuscated
+        test_avro_encoder.encode_batch.assert_called_once()
+        assert_frame_equal(
+            test_avro_encoder.encode_batch.call_args.args[0],
+            _AVRO_ENCODER_INPUT)
+
+        test_kinesis_client.send_records.assert_called_once_with(
+            _ENCODED_RECORDS)
+        test_s3_client.set_state.assert_called_once()
+        test_sierra_client.close_connection.assert_called_once()


### PR DESCRIPTION
Some patron ids erroneously correspond to multiple rows in sierra_view.patron_record_address, leading to duplicate records when this table is joined with sierra_view.record_metadata. To prevent this, for each id, use only the row with the lowest display_order/patron_record_address_type_id.

Also added multi-threading for obfuscation and added test for main method.