### PR TITLE
Add address_helper to reformat potentially malformed addresses that could not initially be geocoded

### DIFF
--- a/helpers/address_helper.py
+++ b/helpers/address_helper.py
@@ -1,0 +1,136 @@
+import re
+
+from helpers.log_helper import create_log
+
+logger = create_log('address_helper')
+
+_ENDS_WITH_POSTAL_CODE = re.compile(r'(^|\s)(\d{5}([\-]?\d{4})?)$')
+_ENDS_WITH_NY_BOROUGH = re.compile(
+    r'(^|\s)(BRONX|BROOKLYN|MANHATTAN|QUEENS|STATEN ISLAND)($|\s(NY|NYC|NEW YORK)$)')  # noqa: E501'
+_ENDS_WITH_NY_NY = re.compile(
+    r'(^|\s)(NY|NYC|NEW YORK)\s(NY|NYC|NEW YORK)$')
+_CONTAINS_NY_STATE = re.compile(r'(^|\s)(NY|NYC|NEW YORK)($|\s)')
+
+
+def reformat_malformed_addresses(address_row):
+    """
+    Looks for common errors in a Sierra address and corrects them:
+
+    1) If the postal_code field does not contain a correct postal code and one
+    of the other fields ends with a string resembling a postal code, use that
+    instead. Then remove anything resembling a postal code from the end of all
+    the other fields.
+    2) If the city field is empty and one of the other fields contains a
+    borough name, use that as the city and set the region to 'NY'
+    3) If the region field is still empty and one of the other fields contains
+    some variation of 'NY', use that instead. We do not check for other state
+    abbreviations because many are also common address abbreviations (e.g FL
+    for floor, LA for lane, etc.). Then remove any borough or variation of 'NY'
+    from the other fields as long as that doesn't result in an empty string.
+    4) Remove anything that's not a digit or '-' from the postal code
+    5) Remove anything that's not a letter, a space, or '- 'from the city and
+    region
+    6) Remove anything that's not a letter, a space, or '-', '#', '&', '.',
+    ',', ';', ':', '+', '@', '/' from the address
+    """
+    processed_address_row = address_row.fillna('').str.strip()
+    if (processed_address_row == '').all():
+        return processed_address_row
+
+    processed_address_row = processed_address_row.str.upper()
+    processed_address_row['original_postal_code'] = processed_address_row[
+        'postal_code']
+    processed_address_row['original_city'] = processed_address_row['city']
+
+    # Step 1) in method description
+    postal_code_match = _ENDS_WITH_POSTAL_CODE.search(
+        processed_address_row['postal_code'])
+    if postal_code_match:
+        processed_address_row['postal_code'] = postal_code_match.group(
+            0).lstrip()
+    else:
+        for col_name in ['address', 'region', 'city']:
+            has_match = _ENDS_WITH_POSTAL_CODE.search(
+                processed_address_row[col_name])
+            if has_match:
+                processed_address_row['postal_code'] = has_match.group(
+                    0).lstrip()
+                break
+    for col_name in ['address', 'region', 'city']:
+        processed_address_row[col_name] = re.sub(
+            _ENDS_WITH_POSTAL_CODE, '', processed_address_row[col_name]
+        ).strip()
+
+    # Step 2) in method description
+    borough_match = _ENDS_WITH_NY_BOROUGH.search(
+        processed_address_row['city'])
+    ny_ny_match = _ENDS_WITH_NY_NY.search(processed_address_row['city'])
+    if borough_match:
+        processed_address_row['city'] = re.sub(
+            _CONTAINS_NY_STATE, '', borough_match.group(0)).strip()
+        processed_address_row['region'] = 'NY'
+    elif ny_ny_match:
+        processed_address_row['city'] = 'NEW YORK'
+        processed_address_row['region'] = 'NY'
+    elif processed_address_row['city'] == '':
+        for col_name in ['address', 'region', 'original_postal_code']:
+            has_borough_match = _ENDS_WITH_NY_BOROUGH.search(
+                processed_address_row[col_name])
+            has_ny_ny_match = _ENDS_WITH_NY_NY.search(
+                processed_address_row[col_name])
+            if has_borough_match:
+                processed_address_row['city'] = re.sub(
+                    _CONTAINS_NY_STATE, '', has_borough_match.group(0)).strip()
+                processed_address_row['region'] = 'NY'
+                break
+            if has_ny_ny_match:
+                processed_address_row['city'] = 'NEW YORK'
+                processed_address_row['region'] = 'NY'
+                break
+    if processed_address_row['city'] == 'MANHATTAN':
+        processed_address_row['city'] = 'NEW YORK'
+
+    # Step 3) in method description
+    ny_state_match = _CONTAINS_NY_STATE.search(processed_address_row['region'])
+    if ny_state_match:
+        processed_address_row['region'] = 'NY'
+    elif processed_address_row['region'] == '':
+        for col_name in ['address', 'original_city', 'original_postal_code']:
+            has_match = _CONTAINS_NY_STATE.search(
+                processed_address_row[col_name])
+            if has_match:
+                processed_address_row['region'] = 'NY'
+                break
+
+    processed_address_row['address'] = re.sub(
+        _ENDS_WITH_NY_BOROUGH, '', processed_address_row['address']
+    ).strip()
+    processed_address_row['address'] = re.sub(
+        _ENDS_WITH_NY_NY, '', processed_address_row['address']
+    ).strip()
+    for col_name in ['address', 'region', 'city', 'postal_code']:
+        new_val = re.sub(
+            _CONTAINS_NY_STATE, '', processed_address_row[col_name]
+        ).strip()
+        if new_val != '':
+            processed_address_row[col_name] = new_val
+
+    # Steps 4)-6) in method description
+    processed_address_row['postal_code'] = re.sub(
+        '[^\\d-]', '', processed_address_row['postal_code']).strip()
+    processed_address_row['city'] = re.sub(
+        '[^A-Za-zÀ-ÖØ-öø-ÿ-\\s]', '', processed_address_row['city']).strip()
+    processed_address_row['region'] = re.sub(
+        '[^A-Za-zÀ-ÖØ-öø-ÿ-\\s]', '', processed_address_row['region']).strip()
+    processed_address_row['address'] = re.sub(
+        '[^A-Za-zÀ-ÖØ-öø-ÿ0-9-\\s#&.,;:+@/]', '',
+        processed_address_row['address']).strip()
+
+    results_row = processed_address_row[[
+        'address', 'city', 'region', 'postal_code']]
+    input_row = address_row.fillna('').str.upper()
+    if not input_row.equals(results_row):
+        logger.info(('Changed geocoder address input from {input} to: {output}'
+                     ).format(input=input_row, output=results_row))
+
+    return processed_address_row[['address', 'city', 'region', 'postal_code']]

--- a/tests/test_address_helper.py
+++ b/tests/test_address_helper.py
@@ -1,0 +1,119 @@
+import pandas as pd
+
+from helpers.address_helper import reformat_malformed_addresses
+from pandas.testing import assert_series_equal
+
+
+class TestAddressHelper:
+
+    def test_empty_address(self):
+        input_row = pd.Series({
+            'address': None,
+            'city': '',
+            'region': '   ',
+            'postal_code': None})
+        output_row = pd.Series({
+            'address': '',
+            'city': '',
+            'region': '',
+            'postal_code': ''})
+        assert_series_equal(
+            reformat_malformed_addresses(input_row), output_row)
+
+    def test_good_address(self):
+        input_row = pd.Series({
+            'address': '123 REAL AVE',
+            'city': 'NEW YORK',
+            'region': 'NY',
+            'postal_code': '11111-2222'})
+        assert_series_equal(
+            reformat_malformed_addresses(input_row), input_row)
+
+    def test_one_line_address(self):
+        input_row = pd.Series({
+            'address': '123 REAL AVE NEW YORK NY 11111-2222',
+            'city': None,
+            'region': None,
+            'postal_code': None})
+        output_row = pd.Series({
+            'address': '123 REAL AVE',
+            'city': 'NEW YORK',
+            'region': 'NY',
+            'postal_code': '11111-2222'})
+        assert_series_equal(
+            reformat_malformed_addresses(input_row), output_row)
+
+    def test_found_postal_code(self):
+        input_df = pd.DataFrame([
+            ['123 REAL AVE 11111', 'NEW YORK', 'NY', None],
+            ['123 REAL AVE', 'NEW YORK 11111', 'NY', None],
+            ['123 REAL AVE', 'NEW YORK', 'NY 11111', None],
+            ['123 REAL AVE 11111', 'NEW YORK 11111', 'NY 11111', 'bad']],
+            columns=['address', 'city', 'region', 'postal_code'])
+        output_row = pd.Series({
+            'address': '123 REAL AVE',
+            'city': 'NEW YORK',
+            'region': 'NY',
+            'postal_code': '11111'})
+
+        for _, input_row in input_df.iterrows():
+            assert_series_equal(
+                reformat_malformed_addresses(input_row), output_row,
+                check_names=False)
+
+    def test_found_borough(self):
+        input_df = pd.DataFrame([
+            ['123 REAL AVE BRONX', None, 'NY', '11111'],
+            ['123 REAL AVE', None, 'BROOKLYN', '11111'],
+            ['123 REAL AVE', None, 'NY', 'STATEN ISLAND'],
+            ['123 REAL AVE QUEENS', None, 'NY QUEENS', 'QUEENS'],
+            ['123 REAL AVE', 'MANHATTAN', 'bad', '11111'],
+            ['123 REAL AVE NEW YORK NY', None, None, '11111'],
+            ['123 REAL AVE NEW YORK', None, None, '11111']],
+            columns=['address', 'city', 'region', 'postal_code'])
+        output_df = pd.DataFrame([
+            ['123 REAL AVE', 'BRONX', 'NY', '11111'],
+            ['123 REAL AVE', 'BROOKLYN', 'NY', '11111'],
+            ['123 REAL AVE', 'STATEN ISLAND', 'NY', ''],
+            ['123 REAL AVE', 'QUEENS', 'NY', ''],
+            ['123 REAL AVE', 'NEW YORK', 'NY', '11111'],
+            ['123 REAL AVE', 'NEW YORK', 'NY', '11111'],
+            ['123 REAL AVE', '', 'NY', '11111']],
+            columns=['address', 'city', 'region', 'postal_code'])
+
+        for index, input_row in input_df.iterrows():
+            assert_series_equal(
+                reformat_malformed_addresses(input_row), output_df.loc[index],
+                check_names=False)
+
+    def test_found_ny_state(self):
+        input_df = pd.DataFrame([
+            ['123 REAL AVE NEW YORK', 'REAL CITY', None, '11111'],
+            ['123 REAL AVE', 'REAL CITY NY', None, '11111'],
+            ['123 REAL AVE', 'REAL CITY', None, 'NYC 11111'],
+            ['123 REAL AVE NY', 'REAL CITY NY', None, '11111 NY']],
+            columns=['address', 'city', 'region', 'postal_code'])
+        output_row = pd.Series({
+            'address': '123 REAL AVE',
+            'city': 'REAL CITY',
+            'region': 'NY',
+            'postal_code': '11111'})
+
+        for _, input_row in input_df.iterrows():
+            assert_series_equal(
+                reformat_malformed_addresses(input_row), output_row,
+                check_names=False)
+
+    def test_character_replacement(self):
+        input_row = pd.Series({
+            'address': '1\\2"3\' $R%E{A[L∆ AVE',
+            'city': 'N1E2W3 Y.O,R#K',
+            'region': '1N&Y.',
+            'postal_code': 'abc11111-2.2,2+2d'})
+        output_row = pd.Series({
+            'address': '123 REAL AVE',
+            'city': 'NEW YORK',
+            'region': 'NY',
+            'postal_code': '11111-2222'})
+        assert_series_equal(
+            reformat_malformed_addresses(input_row), output_row)


### PR DESCRIPTION
Also remove backslashes and single/double quotes before sending addresses to geocoder as these characters can accidentally break the csv formatting.

Also added an API key for the geocoder.