### PR TITLE
Add GitHub actions for CI/CD

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,55 @@
+name: Deploy to production
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  check_production_tag:
+    name: Check if the release is tagged as production
+    runs-on: ubuntu-latest
+    outputs:
+      has_production_tag: ${{ steps.check-production-tag.outputs.run_jobs }}
+    steps:
+      - name: check production tag ${{ github.ref }}
+        id: check-production-tag
+        run: |
+          if [[${{ github.ref }} =~ refs\/tags\/production ]]; then
+            echo "::set-output name=run_jobs::true"
+          else
+            echo "::set-output name=run_jobs::false"
+          fi
+  publish_production:
+    needs: [ check_production_tag ]
+    if: needs.check_production_tag.outputs.has_production_tag == 'true'
+    name: Publish image to ECR and update ECS stack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: patron-info-poller
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
+      
+      - name: Force ECS Update
+        run: |
+          aws ecs update-service --cluster patron-info-poller-production --service patron-info-poller-app-production --force-new-deployment

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -1,0 +1,55 @@
+name: Deploy to QA
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  check_qa_tag:
+    name: Check if the release is tagged as QA
+    runs-on: ubuntu-latest
+    outputs:
+      has_qa_tag: ${{ steps.check-qa-tag.outputs.run_jobs }}
+    steps:
+      - name: check qa tag ${{ github.ref }}
+        id: check-qa-tag
+        run: |
+          if [[${{ github.ref }} =~ refs\/tags\/qa ]]; then
+            echo "::set-output name=run_jobs::true"
+          else
+            echo "::set-output name=run_jobs::false"
+          fi
+  publish_qa:
+    needs: [ check_qa_tag ]
+    if: needs.check_qa_tag.outputs.has_qa_tag == 'true'
+    name: Publish image to ECR and update ECS stack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: patron-info-poller
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+      
+      - name: Force ECS Update
+        run: |
+          aws ecs update-service --cluster patron-info-poller-qa --service patron-info-poller-app-qa --force-new-deployment

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,11 +9,8 @@ jobs:
     name: Updates changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: "CHANGELOG.md"
-          skipLabels: "no-changelog", "skip-changelog"
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,37 @@
+name: Run Python unit tests
+
+on: 
+  pull_request:
+    actions: [ opened ]
+
+jobs:
+  changelog:
+    name: Updates changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: "CHANGELOG.md"
+          skipLabels: "no-changelog", "skip-changelog"
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run linter and test suite
+        run: |
+          make lint
+          make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2022-01-19 -- v0.0.4
+### Added
+- Added Github actions workflows for running tests and deploying to QA and
+production
+
 ## 2022-12-27 -- v0.0.3
 ### Added
 - Added controller to allow for different types of pipeline runs

--- a/lib/avro_encoder.py
+++ b/lib/avro_encoder.py
@@ -1,5 +1,4 @@
 import avro.schema
-import base64
 import json
 import os
 import requests

--- a/lib/pipeline_controller.py
+++ b/lib/pipeline_controller.py
@@ -248,8 +248,8 @@ class PipelineController:
         Redshift. If they do, take the geoid and obfuscated patron id from
         Redshift and join it with the original Sierra dataframe.
         """
-        address_hashes_str = ','.join(str(all_patrons_df['address_hash'].values)
-            [1:-1].split())
+        address_hashes_str = ','.join(
+            str(all_patrons_df['address_hash'].values)[1:-1].split())
         redshift_raw_data = redshift_client.execute_query(
             build_redshift_address_query(address_hashes_str))
         redshift_df = pd.DataFrame(
@@ -268,8 +268,8 @@ class PipelineController:
         Finds the Redshift data for recently deleted patrons and joins it with
         the deletion date from Sierra.
         """
-        patron_ids_str = ','.join(str(deleted_patrons_df['patron_id'].values)
-            [1:-1].split())
+        patron_ids_str = ','.join(
+            str(deleted_patrons_df['patron_id'].values)[1:-1].split())
         redshift_raw_data = redshift_client.execute_query(
             build_redshift_patron_query(patron_ids_str))
         redshift_df = pd.DataFrame(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,12 +20,13 @@ class TestMain:
     def test_instance(self, mocker):
         mocker.patch('main.load_env_file')
         mocker.patch('main.create_log')
-    
+
     def test_main_without_backfill(self, test_instance, mocker):
         os.environ['BACKFILL'] = 'False'
 
         mock_pipeline_controller = mocker.MagicMock()
-        mocker.patch('main.PipelineController', return_value=mock_pipeline_controller)
+        mocker.patch('main.PipelineController',
+                     return_value=mock_pipeline_controller)
         main.main()
         mock_pipeline_controller.run_pipeline.assert_has_calls([
             mocker.call(PipelineMode.NEW_PATRONS),
@@ -33,13 +34,15 @@ class TestMain:
             mocker.call(PipelineMode.DELETED_PATRONS)])
 
         del os.environ['BACKFILL']
-        
+
     def test_main_with_backfill(self, test_instance, mocker):
         os.environ['BACKFILL'] = 'True'
 
         mock_pipeline_controller = mocker.MagicMock()
-        mocker.patch('main.PipelineController', return_value=mock_pipeline_controller)
+        mocker.patch('main.PipelineController',
+                     return_value=mock_pipeline_controller)
         main.main()
-        mock_pipeline_controller.run_pipeline.assert_called_once_with(PipelineMode.NEW_PATRONS)
+        mock_pipeline_controller.run_pipeline.assert_called_once_with(
+            PipelineMode.NEW_PATRONS)
 
         del os.environ['BACKFILL']


### PR DESCRIPTION
Automatically deploys to QA/production when a release tagged as either "qa" or "production" is created. Automatically runs linter and tests and checks that the CHANGELOG has been updated when a new PR is opened.