### PR TITLE
Ignore pandas FutureWarning

### DIFF
--- a/lib/geocoder_api_client.py
+++ b/lib/geocoder_api_client.py
@@ -1,3 +1,6 @@
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
 import os
 import pandas as pd
 import requests

--- a/lib/pipeline_controller.py
+++ b/lib/pipeline_controller.py
@@ -1,3 +1,6 @@
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
 import datetime
 import os
 import pandas as pd


### PR DESCRIPTION
This warning does not affect us and is fired every time the update method is called on a dataframe:

FutureWarning: In a future version, `df.iloc[:, i] = newvals` will attempt to set the values inplace instead of always setting a new array. To retain the old behavior, use either `df[df.columns[i]] = newvals` or, if columns are non-unique, `df.isetitem(i, newvals)`