### PR TITLE
Translate addresses to ascii to avoid geocoder errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 2023-03-27 -- v0.0.8
+## 2023-04-03 -- v1.0.3
+### Fixed
+- Handle case when all addresses have been geocoded by the census geocoder
+- Translate all addresses to ascii before sending to NYC geocoder to avoid
+errors
+
+## 2023-03-27 -- v1.0.0
 ### Added
 - Added NYC-specific geocoder to try and geocode any address that weren't found
 by the census geocoder

--- a/helpers/address_helper.py
+++ b/helpers/address_helper.py
@@ -2,6 +2,8 @@ import re
 import usaddress
 
 from nypl_py_utils.functions.log_helper import create_log
+from unidecode import unidecode
+
 
 logger = create_log('address_helper')
 
@@ -49,18 +51,21 @@ def reformat_malformed_address(address_row):
 
     # Strip the city and region of anything that's not a letter, space, or -.
     address_row['city'] = re.sub('[^A-Za-zÀ-ÖØ-öø-ÿ-\\s]', '',
-                                 address_row['city']).strip()
+                                 unidecode(address_row['city'])).strip()
     address_row['region'] = re.sub('[^A-Za-zÀ-ÖØ-öø-ÿ-\\s]', '',
-                                   address_row['region']).strip()
+                                   unidecode(address_row['region'])).strip()
     # Strip the street_name and address of anything that's not a letter, space,
     # digit, or common punctuation.
-    address_row['street_name'] = re.sub('[^A-Za-zÀ-ÖØ-öø-ÿ0-9-\\s#&.,;:+@/]',
-                                        '', address_row['street_name']).strip()
+    address_row['street_name'] = re.sub(
+        '[^A-Za-zÀ-ÖØ-öø-ÿ0-9-\\s#&.,;:+@/]', '',
+        unidecode(address_row['street_name'])).strip()
     address_row['address'] = re.sub('[^A-Za-zÀ-ÖØ-öø-ÿ0-9-\\s#&.,;:+@/]', '',
-                                    address_row['address']).strip()
+                                    unidecode(address_row['address'])).strip()
     # Strip the postal_code of anything that's not a digit or -.
-    address_row['postal_code'] = re.sub('[^\\d-]', '',
-                                        address_row['postal_code']).strip()
+    address_row['postal_code'] = re.sub(
+        '[^\\d-]', '', unidecode(address_row['postal_code'])).strip()
+    # Translate the house_number to ascii
+    address_row['house_number'] = unidecode(address_row['house_number'])
     return address_row
 
 

--- a/lib/nyc_geocoder_client.py
+++ b/lib/nyc_geocoder_client.py
@@ -28,7 +28,7 @@ class NycGeocoderClient:
         """
         self.logger.info(
             'Sending ({}) addresses to NYC geocoder'.format(len(address_df)))
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=2) as executor:
             geoids_list = list(executor.map(
                 self._geocode_address, address_df.iterrows()))
 

--- a/lib/pipeline_controller.py
+++ b/lib/pipeline_controller.py
@@ -177,7 +177,7 @@ class PipelineController:
             processed_df['city'].fillna('') + '_' +
             processed_df['region'].fillna('') + '_' +
             processed_df['postal_code'].fillna(''))
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=2) as executor:
             processed_df['address_hash'] = list(executor.map(
                 obfuscate, processed_df['address_hash_plaintext']))
 
@@ -257,7 +257,7 @@ class PipelineController:
         # Obfuscate the patron ids using bcrypt
         self.logger.info('Obfuscating ({}) patron ids'.format(
             len(processed_df)))
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=2) as executor:
             processed_df['patron_id'] = list(executor.map(
                 obfuscate, processed_df['patron_id_plaintext']))
 
@@ -333,7 +333,7 @@ class PipelineController:
         address_df = unknown_patrons_df.copy()
         self.logger.info('Obfuscating ({}) patron ids'.format(
             len(address_df)))
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=2) as executor:
             address_df['patron_id'] = list(executor.map(
                 obfuscate, address_df['patron_id_plaintext']))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ pytest-mock
 python-geosupport
 requests
 requests-mock
+unidecode
 usaddress

--- a/tests/test_address_helper.py
+++ b/tests/test_address_helper.py
@@ -59,15 +59,15 @@ class TestAddressHelper:
 
     def test_character_replacement(self, mocker):
         input_row = pd.Series({
-            'address': '123 $R%E{A[L∆ AVE',
+            'address': '123 $R%E{A[L∆ ÁVE',
             'city': 'N1E2W3 Y.O,R#K',
             'region': '1N&Y.',
             'postal_code': 'abc11111-2.2,2+2d',
-            'full_address': ('123 $R%E{A[L∆ AVE N1E2W3 Y.O,R#K 1N&Y. '
+            'full_address': ('123 $R%E{A[L∆ ÁVE N1E2W3 Y.O,R#K 1N&Y. '
                              'abc11111-2.2,2+2d')})
         mocker.patch('usaddress.tag', return_value=(OrderedDict([
             ('AddressNumber', '123'),
-            ('street', '$R%E{A[L∆ AVE'),
+            ('street', '$R%E{A[L∆ ÁVE'),
             ('PlaceName', 'N1E2W3 Y.O,R#K'),
             ('StateName', '1N&Y.'),
             ('ZipCode', 'abc11111-2.2,2+2d')]),
@@ -77,7 +77,7 @@ class TestAddressHelper:
             'city': 'NEW YORK',
             'region': 'NY',
             'postal_code': '11111-2222',
-            'full_address': ('123 $R%E{A[L∆ AVE N1E2W3 Y.O,R#K 1N&Y. '
+            'full_address': ('123 $R%E{A[L∆ ÁVE N1E2W3 Y.O,R#K 1N&Y. '
                              'abc11111-2.2,2+2d'),
             'house_number': '123',
             'street_name': 'REAL AVE'})


### PR DESCRIPTION
The NYC geocoder throws an error when it encounters unicode-only characters like accents