### PR TITLE
Ignore records with NULL dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2023-04-05 -- v1.0.4
+- Use nypl-py-utils v1.0.1
+- Ignore NULL dates when querying Sierra 
+
 ## 2023-04-03 -- v1.0.3
 ### Fixed
 - Handle case when all addresses have been geocoded by the census geocoder

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ help:
 	@echo "    lint project files using the flake8 linter"
 
 run:
-	export ENVIRONMENT=devel; \
-	python3 main.py
+	docker image build -t patron-info-poller:local .; \
+	docker container run -e ENVIRONMENT=devel patron-info-poller:local
 
 test:
 	pytest

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -14,6 +14,7 @@ _NEW_PATRONS_QUERY = '''
         FROM sierra_view.record_metadata
         WHERE record_type_code = 'p'
             AND creation_date_gmt >= '{cached_creation_dt}'
+            AND creation_date_gmt IS NOT NULL
         ORDER BY creation_date_gmt
         LIMIT {limit}) x
     LEFT JOIN sierra_view.patron_record_address
@@ -37,6 +38,7 @@ _UPDATED_PATRONS_QUERY = '''
         FROM sierra_view.record_metadata
         WHERE record_type_code = 'p'
             AND record_last_updated_gmt >= '{cached_update_dt}'
+            AND record_last_updated_gmt IS NOT NULL
         ORDER BY record_last_updated_gmt
         LIMIT {limit}) x
     LEFT JOIN sierra_view.patron_record_address
@@ -52,6 +54,7 @@ _DELETED_PATRONS_QUERY = '''
     FROM sierra_view.record_metadata
     WHERE record_type_code = 'p'
         AND deletion_date_gmt >= '{cached_deletion_date}'
+        AND deletion_date_gmt IS NOT NULL
     ORDER BY deletion_date_gmt
     LIMIT {limit};'''
 

--- a/lib/pipeline_controller.py
+++ b/lib/pipeline_controller.py
@@ -196,10 +196,11 @@ class PipelineController:
             pd.isnull(processed_df['patron_id'])][
             ['address', 'city', 'region', 'postal_code',
              'patron_id_plaintext']]
-        geocoded_df = self._process_unknown_patrons(unknown_patrons_df)
-        with warnings.catch_warnings():
-            warnings.simplefilter(action='ignore', category=FutureWarning)
-            processed_df.update(geocoded_df)
+        if len(unknown_patrons_df) > 0:
+            geocoded_df = self._process_unknown_patrons(unknown_patrons_df)
+            with warnings.catch_warnings():
+                warnings.simplefilter(action='ignore', category=FutureWarning)
+                processed_df.update(geocoded_df)
 
         # Modify the data to match what's expected by the PatronInfo Avro
         # schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flake8
 numpy
-nypl-py-utils[avro-encoder,kinesis-client,postgresql-client,redshift-client,s3-client,config-helper,obfuscation-helper]==1.0.0
+nypl-py-utils[avro-encoder,kinesis-client,postgresql-client,redshift-client,s3-client,config-helper,obfuscation-helper]==1.0.1
 pandas
 pytest
 pytest-mock


### PR DESCRIPTION
PostgreSQL orders NULL as after every other date, so if NULL were not ignored then the poller would set the cached dates to NULL and continuously check these records.

Also update the README and bump the nypl-py-utils version.